### PR TITLE
Only inspect callbacks when adding them, only call callbacks when state changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for aiosenseme library
 
+## v0.5.1
+
+* Determine a callback type (coroutine or function) only when adding the callback. The reduces overhead in callbacks.
+* Callbacks are stopped when the device is waiting for the first update and can only occur when a parameter has changed. Callback frequency has been significantly reduced.
+* Thanks go to [bdraco](https://github.com/bdraco) for help in making these changes.
+
 ## v0.5.0
 
 * Devices can now be added with an IP address instead of being discovered. Some network configurations will not allow UDP Discovery packets through but a direct TCP connection will work.

--- a/aiosenseme/device.py
+++ b/aiosenseme/device.py
@@ -695,10 +695,14 @@ class SensemeDevice:
 
     def _execute_callbacks(self):
         """Run all callbacks to indicate something has changed."""
+        count = 0
         for callback in self._callbacks:
+            count += 1
             callback()
         for callback in self._coroutine_callbacks:
+            count += 1
             asyncio.create_task(callback())
+        _LOGGER.debug("%s: %s callback(s) happened.", self.name, count)
 
     def _send_command(self, cmd):
         """Send a command to SenseME device."""
@@ -751,26 +755,27 @@ class SensemeDevice:
                 # ignore time parameter
                 continue
             if self._data.get(key, "?????") == value:
-                # parameter is the same value
+                # parameter has not changed, nothing to do
                 continue
+            self._data[key] = value # update new key/value or changed value
+            _LOGGER.debug("%s: Param updated: [%s]='%s'", self.name, key, value)
             if self.is_fan:
                 if key == "WINTERMODE;STATE":
-                    self._first_update = True
+                    if not self._first_update:
+                        self._first_update = True
+                        _LOGGER.debug("%s: First Update Complete", self.name)
             elif self.is_light:
                 if key == "SNSROCC;TIMEOUT;MIN":
-                    self._first_update = True
+                    if not self._first_update:
+                        self._first_update = True
+                        _LOGGER.debug("%s: First Update Complete", self.name)
             elif not self.is_fan and not self.is_light:
                 if key == "SNSROCC;TIMEOUT;MIN":
-                    self._first_update = True
-            if key not in self._data or self._data[key] != value:
+                    if not self._first_update:
+                        self._first_update = True
+                        _LOGGER.debug("%s: First Update Complete", self.name)
+            if self._first_update:
                 data_changed = True
-            self._data[key] = value
-            _LOGGER.debug(
-                "%s: Param updated: [%s]='%s'",
-                self.name,
-                key,
-                value,
-            )
             # update certain local variables that are not part of data
             if key == "FW;NAME":
                 self._fw_name = value
@@ -801,7 +806,6 @@ class SensemeDevice:
                 if self._has_sensor is None:
                     value = value.upper()
                     self._has_sensor = value == "PRESENT"
-
         return "", data_changed
 
     def _send_update(self):

--- a/aiosenseme/device.py
+++ b/aiosenseme/device.py
@@ -30,6 +30,7 @@ PORT = 31415
 ONOFF = ["ON", "OFF"]
 DIRECTIONS = ["FWD", "REV"]
 AUTOCOMFORTS = ["OFF", "COOLING", "HEATING", "FOLLOWTSTAT"]
+INVALID_DATA = "?????"  # data we never expect to be send by the device
 ROOM_TYPES = [
     "Undefined",  # 0, not in a room
     "Other",  # 1
@@ -750,7 +751,7 @@ class SensemeDevice:
             if key == "TIME;VALUE":
                 # ignore time parameter
                 continue
-            if self._data.get(key, "?????") == value:
+            if self._data.get(key, INVALID_DATA) == value:
                 # parameter is the same value
                 continue
             if self.is_fan:

--- a/aiosenseme/device.py
+++ b/aiosenseme/device.py
@@ -758,7 +758,7 @@ class SensemeDevice:
             if self._data.get(key, INVALID_DATA) == value:
                 # parameter has not changed, nothing to do
                 continue
-            self._data[key] = value # update new key/value or changed value
+            self._data[key] = value  # update new key/value or changed value
             _LOGGER.debug("%s: Param updated: [%s]='%s'", self.name, key, value)
             if self.is_fan:
                 if key == "WINTERMODE;STATE":

--- a/aiosenseme/device.py
+++ b/aiosenseme/device.py
@@ -30,7 +30,7 @@ PORT = 31415
 ONOFF = ["ON", "OFF"]
 DIRECTIONS = ["FWD", "REV"]
 AUTOCOMFORTS = ["OFF", "COOLING", "HEATING", "FOLLOWTSTAT"]
-INVALID_DATA = "?????"  # data we never expect to be send by the device
+INVALID_DATA = "?????"  # data we never expect to be sent by the device
 ROOM_TYPES = [
     "Undefined",  # 0, not in a room
     "Other",  # 1
@@ -854,7 +854,6 @@ class SensemeDevice:
                 if self._error_count > 10:
                     _LOGGER.error("%s: Listener task too many errors", self.name)
                     self._is_connected = False
-                    self._execute_callbacks()
                     self._updater_task.cancel()
                     if self._endpoint is not None:
                         self._endpoint.close()
@@ -862,7 +861,6 @@ class SensemeDevice:
                     break
                 if self._endpoint is None:
                     self._is_connected = False
-                    self._execute_callbacks()
                     self._endpoint = SensemeEndpoint()
                     try:
                         _LOGGER.debug("%s: Connecting", self.name)

--- a/aiosenseme/version.py
+++ b/aiosenseme/version.py
@@ -1,3 +1,3 @@
 """Version for aiosenseme library."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
`inspect.iscoroutinefunction` can be more expensive than the callback itself so only do it on add.

In HomeAssistant we check and then store this to avoid the call each time we run a callback : https://github.com/home-assistant/core/blob/dev/homeassistant/core.py#L163

The callbacks are running a bit too frequently still so we end up writing state ~100 times per minute per fan.

<img width="770" alt="Screen Shot 2021-02-26 at 11 47 11 AM" src="https://user-images.githubusercontent.com/663432/109336008-698ff880-7828-11eb-9ffd-bcb8d8af6de4.png">
