### PR TITLE
Use synchronization primitives to avoid sleeping during first update

### DIFF
--- a/aiosenseme/device.py
+++ b/aiosenseme/device.py
@@ -19,7 +19,6 @@ import inspect
 import ipaddress
 import logging
 import random
-import time
 import traceback
 from typing import Any, Callable, Tuple
 


### PR DESCRIPTION
Shaves off some startup time

Before
'senseme': datetime.timedelta(seconds=11, microseconds=396124),

After
'senseme': datetime.timedelta(seconds=7, microseconds=358277),